### PR TITLE
PPDC-567 (Fix misspelling under About page)

### DIFF
--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -620,7 +620,7 @@ const AboutView = ({ data }) => {
         <hr className={classes.listDiverHr} />
 
         {/* Open Pediatric Cancer (OpenPedCan) */}
-        {listHeader("Open Pediatric Cancer %acronym", "OpenPedCan ", "openPedCanDS")}
+        {listHeader("Open Pediatric Cancer %acronym", "OpenPedCan", "openPedCanDS")}
         {showHide.openPedCanDS && openPedCanDataSource()}
         <hr className={classes.listDiverHr} />
 
@@ -640,7 +640,7 @@ const AboutView = ({ data }) => {
         <hr className={classes.listDiverHr} />
 
         {/* Oncology Knowledge Base (OncoKB) Cancer Gene List */}
-        {listHeader("Oncology Knowledge Base %acronym Cancer Gene List", "OncoKB ", "oncokbDS")}
+        {listHeader("Oncology Knowledge Base %acronym Cancer Gene List", "OncoKB", "oncokbDS")}
         {showHide.oncokbDS && oncokbDataSource()}
         <hr className={classes.listDiverHr} />
         

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -614,8 +614,8 @@ const AboutView = ({ data }) => {
           Pediatric Cancer Data Sources
         </Typography>
 
-        {/* FDA Pediatric Molecular Targets Lists (FDA PMTL) */}
-        {listHeader("FDA Pediatric Molecular Targets Lists %acronym", "FDA PMTL", "fdaPmtlDS")}
+        {/* FDA Pediatric Molecular Target Lists (FDA PMTL) */}
+        {listHeader("FDA Pediatric Molecular Target Lists %acronym", "FDA PMTL", "fdaPmtlDS")}
         {showHide.fdaPmtlDS && fdaPmtlDataSource()}
         <hr className={classes.listDiverHr} />
 
@@ -660,8 +660,8 @@ const AboutView = ({ data }) => {
         {showHide.pedCanDataNavDV && pedCanDataNavDataVisualizations()}
         <hr className={classes.listDiverHr} />
 
-        {/* FDA Pediatric Molecular Targets Lists (FDA PMTL) */}
-        {listHeader("FDA Pediatric Molecular Targets Lists %acronym","FDA PMTL", "fdaPmtlDV")}
+        {/* FDA Pediatric Molecular Target Lists (FDA PMTL) */}
+        {listHeader("FDA Pediatric Molecular Target Lists %acronym","FDA PMTL", "fdaPmtlDV")}
         {showHide.fdaPmtlDV && fdaPmtlDataVisualizations()}
         <hr className={classes.listDiverHr} />
 

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -207,7 +207,7 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE: 
           <Link to="https://www.fda.gov/about-fda/oncology-center-excellence/pediatric-oncology#target" external>{' '} 
-            FDA Pediatric Molecular Target List<ExternalLinkIcon />{' '}
+            FDA Pediatric Molecular Target Lists<ExternalLinkIcon />{' '}
           </Link><br/> 
           Where this data is used in the MTP: 
           <Link to="/fda-pmtl">{' '} 


### PR DESCRIPTION
In this PR:
- Spelling issues under About Page are fixed.
- Remove character 's' from "FDA Pediatric Molecular **Targets** Lists" to be "FDA Pediatric Molecular **Target** Lists"
- Add character 's' to "FDA Pediatric Molecular Target **List**" to be "FDA Pediatric Molecular Target **Lists**"
- Remove space character before closing quotation mark