### PR TITLE
PPDC-544 (Update space consistency under About page)

### DIFF
--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -44,6 +44,9 @@ const useStyles = makeStyles(theme => ({
     margin: '58px 0 0px 0',
     fontSize: '16px'
   },
+  datasetContainer: {
+    fontSize: '16px'
+  },
   centerText: {
     textAlign: 'center'
   },
@@ -111,6 +114,9 @@ const useStyles = makeStyles(theme => ({
   },
   space: {
     marginBottom: '64px'
+  },
+  space90: {
+    marginBottom: '90px'
   },
   projectTitle: {
     color: '#2188D8'
@@ -665,12 +671,12 @@ const AboutView = ({ data }) => {
           </Link>.
         </Typography>
 
-        <div className={classes.space}></div>
+        <div className={classes.space90}></div>
       </Grid>
     </Grid>
     
     {/* Pediatric Cancer Data Sources */}
-    <Grid container justify="center" className={classes.container}>
+    <Grid container justify="center" className={classes.datasetContainer}>
       <Grid item xs={10} md={8} lg={7} xl={6} className={classes.introContainer}>
         <Typography variant="h4" component="h1" align="center" className={classNames(classes.title, classes.boxTitle)}>
           Pediatric Cancer Data Sources
@@ -711,13 +717,13 @@ const AboutView = ({ data }) => {
         {showHide.gtexDS && gtexDataSource()}
         <hr className={classes.listDiverHr} />
 
-        <div className={classes.space}></div>
+        <div className={classes.space90}></div>
 
       </Grid>
     </Grid>
 
     {/* Pediatric Cancer Data Processing */}
-    <Grid container justify="center" className={classes.container}>
+    <Grid container justify="center" className={classes.datasetContainer}>
       <Grid item xs={10} md={8} lg={7} xl={6} className={classes.introContainer}>
         <Typography variant="h4" component="h1" align="center" className={classNames(classes.title, classes.boxTitle)}>
           Pediatric Cancer Data Processing
@@ -732,13 +738,13 @@ const AboutView = ({ data }) => {
           </Link>.
         </Typography>
 
-        <div className={classes.space}></div>
+        <div className={classes.space90}></div>
 
       </Grid>
     </Grid>
 
     {/* Pediatric Cancer Data Visualizations */}
-    <Grid container justify="center" className={classes.container}>
+    <Grid container justify="center" className={classes.datasetContainer}>
       <Grid item xs={10} md={8} lg={7} xl={6} className={classes.introContainer}>
         <Typography variant="h4" component="h1" align="center" className={classNames(classes.title, classes.boxTitle)}>
           Pediatric Cancer Data Visualizations

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -34,10 +34,13 @@ const useStyles = makeStyles(theme => ({
     fontSize: '16px'
   },
   changeLogContainer: {
-    marginBottom: '68px',
+    marginTop: '80px',
     backgroundColor: '#EDF1F4',
     color: '#000000',
     fontSize: '16px',
+    padding:'55px 40px 85px 40px',
+  },
+  changeLogSubContainer: {
     padding:'55px 40px 0px 40px',
   },
   container: {
@@ -516,7 +519,7 @@ const AboutView = ({ data }) => {
   // Temporally solution to offset when scrolling to specific section of page.
   const ChangeLogOffset = () => {
     return (
-      <p id="changeLog" style={{display: 'block', position: 'relative', top: '-120px', visibility: 'hidden'}}></p>
+      <p id="changeLog" style={{display: 'block', position: 'relative', top: '-130px', visibility: 'hidden'}}></p>
     )
   }
 
@@ -774,7 +777,7 @@ const AboutView = ({ data }) => {
 
     {/* Change Log */}
     <ChangeLogOffset />
-    <Grid container justify="center" className={[classes.container,classes.changeLogContainer]}>
+    <Grid container justify="center" className={classes.changeLogContainer}>
       <Grid item xs={10} md={8} lg={7} xl={6} className={classes.introContainer}>
 
         <Typography variant="h4" component="h1" align="center" paragraph className={classes.title}>
@@ -786,7 +789,7 @@ const AboutView = ({ data }) => {
           at varying intervals. In order to comprehensively track changes, the various changelogs are aggregated here.
         </Typography>
         
-        <Grid item className={classes.changeLogContainer}>
+        <Grid item className={classes.changeLogSubContainer}>
           <Paper className={classes.changeLogPaper}>
             <div className={classes.changeLogBox}>
               <div className={classes.changeLogBoxLeft} >


### PR DESCRIPTION
In this PR:
- Under About page, the space between the dataset section has been updated to be more consistent. A total of 120px has been added.
- 85px of space has been added at the end of "Pediatric Cancer Data Visualizations" before the Change log section and equally 85px of space has been added before the "Change log" Sub-header.

Related Tickets: PPDC-544 and PPDC-573 