### PR TITLE
(PPDC-645 and PPDC-650) Push down Drawer based on fixed MTP header

### DIFF
--- a/src/components/PublicationsDrawer/PublicationsDrawer.js
+++ b/src/components/PublicationsDrawer/PublicationsDrawer.js
@@ -29,6 +29,7 @@ const sourceDrawerStyles = makeStyles(theme => ({
   },
   drawerPaper: {
     backgroundColor: theme.palette.grey[300],
+    ...theme.Drawer.paper,
   },
   drawerTitle: {
     borderBottom: '1px solid #ccc',

--- a/src/components/Table/DataDownloader.js
+++ b/src/components/Table/DataDownloader.js
@@ -132,8 +132,7 @@ const styles = makeStyles(theme => ({
   container: {
     width: '80%',
     backgroundColor: theme.palette.grey[300],
-    marginTop: '262px',
-    height: 'calc(100% - 262px)',
+    ...theme.Drawer.paper,
   },
   paper: {
     margin: '1.5rem',

--- a/src/components/Table/TableDrawer.js
+++ b/src/components/Table/TableDrawer.js
@@ -34,6 +34,7 @@ const sourceDrawerStyles = makeStyles(theme => ({
   },
   drawerPaper: {
     backgroundColor: theme.palette.grey[300],
+    ...theme.Drawer.paper,
   },
   drawerTitle: {
     borderBottom: '1px solid #ccc',

--- a/src/theme.js
+++ b/src/theme.js
@@ -137,6 +137,12 @@ const theme = {
       },
     },
   },
+  Drawer: {
+    paper: {
+      marginTop: '262px',
+      height: 'calc(100% - 262px)',
+    }
+  },
 };
 
 export default theme;


### PR DESCRIPTION
In this PR:
- The Drawer issue of overlapping with MTP headers has been fixed by pushing down the Drawer component by 262px to accommodate the fixed MTP header

Related Tickets: PPDC-645 and PPDC-650