### PR TITLE
PPDC-643 (Add Sticky Header and update style for SA tables )

### DIFF
--- a/src/components/Table/DataTable.js
+++ b/src/components/Table/DataTable.js
@@ -27,6 +27,7 @@ function DataTable({
   loading,
   query,
   variables,
+  stickyHeader,
 }) {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(initialPageSize);
@@ -102,6 +103,7 @@ function DataTable({
       loading={loading}
       query={query}
       variables={variables}
+      stickyHeader={stickyHeader}
     />
   );
 }

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -50,6 +50,7 @@ const Table = ({
   rowIsSelectable = false,
   query,
   variables,
+  stickyHeader,
 }) => {
   const emptyRows = pageSize - rows.length;
   const [selectedRow, setSelectedRow] = useState(0);
@@ -106,12 +107,15 @@ const Table = ({
         )}
       </Grid>
       <TableContainer
-        className={classNames(defaultClasses.container, classes.root)}
+        className={classNames(defaultClasses.container, classes.root, {
+          [defaultClasses.stickyHeader]: stickyHeader,
+        })}
       >
         <MuiTable
           className={classNames(defaultClasses.table, classes.table, {
             [defaultClasses.tableFixed]: fixed,
           })}
+          stickyHeader={stickyHeader}
         >
           <TableHeader
             columns={columns}
@@ -120,6 +124,7 @@ const Table = ({
             order={order}
             sortBy={sortBy}
             onRequestSort={handleSort}
+            stickyHeader={stickyHeader}
           />
           <TableBody>
             {rows.map((row, i) => (

--- a/src/components/Table/TableHeader.js
+++ b/src/components/Table/TableHeader.js
@@ -30,6 +30,7 @@ function HeaderCell({
   tooltip,
   tooltipStyle = {},
   width,
+  stickyHeader,
 }) {
   const headerClasses = tableStyles();
 
@@ -63,6 +64,7 @@ function HeaderCell({
             [headerClasses.cellGroup]: isHeaderGroup,
             [headerClasses.cellSticky]: sticky,
             [headerClasses.noWrap]: noWrapHeader,
+            [headerClasses.headerCellSticky]: stickyHeader && sticky,
           }
         ),
       }}
@@ -89,6 +91,7 @@ function TableHeader({
   onRequestSort,
   sortBy,
   width,
+  stickyHeader,
 }) {
   const colspans = useDynamicColspan(headerGroups, columns, width);
   const createSortHandler = property => event => {
@@ -139,6 +142,7 @@ function TableHeader({
               tooltipStyle={column.tooltipStyle}
               width={column.width}
               minWidth={column.minWidth}
+              stickyHeader={stickyHeader}
             />
           </Hidden>
         ))}

--- a/src/components/Table/tableStyles.js
+++ b/src/components/Table/tableStyles.js
@@ -22,6 +22,12 @@ export const tableStyles = makeStyles(theme => ({
       borderLeft: 'none',
     },
   },
+  headerCellSticky: {
+    zIndex: 3,
+  },
+  stickyHeader: {
+    maxHeight: '440px',
+  },
   cellSticky: {
     position: 'sticky',
     left: 0,

--- a/src/components/Table/tableStyles.js
+++ b/src/components/Table/tableStyles.js
@@ -26,7 +26,7 @@ export const tableStyles = makeStyles(theme => ({
     zIndex: 3,
   },
   stickyHeader: {
-    maxHeight: '640px',
+    maxHeight: '540px',
   },
   cellSticky: {
     position: 'sticky',

--- a/src/components/Table/tableStyles.js
+++ b/src/components/Table/tableStyles.js
@@ -26,7 +26,7 @@ export const tableStyles = makeStyles(theme => ({
     zIndex: 3,
   },
   stickyHeader: {
-    maxHeight: '440px',
+    maxHeight: '640px',
   },
   cellSticky: {
     position: 'sticky',

--- a/src/sections/common/OpenPedCanSomaticAlterations/CnvByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/CnvByGeneTab.js
@@ -4,12 +4,12 @@ import { Grid } from '@material-ui/core';
 import { DataTable } from '../../../components/Table';
 import { defaultRowsPerPageOptions } from '../../../constants';
 import  Link from '../../../components/Link';
-import { renderPMTLCell } from './utils';
+import { renderPMTLCell, addCustomFields } from './utils';
 
 import { genericComparator } from '../../../utils/comparators'
 
 // Configuration for how the tables will display the data
-const columns = [
+let columns = [
   { id: 'geneSymbol', label: 'Gene symbol',
     renderCell: ({ geneSymbol, targetFromSourceId }) => 
       <Link to={`/target/${targetFromSourceId}`}> {geneSymbol} </Link> },
@@ -60,6 +60,8 @@ const dataDownloaderColumns = [
 ]
 
 function CnvByGeneTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }) {
+  // Set a minimum column width
+  addCustomFields(columns)
   return (
     <Grid container>
       <Grid item xs={12}>

--- a/src/sections/common/OpenPedCanSomaticAlterations/CnvByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/CnvByGeneTab.js
@@ -75,6 +75,7 @@ function CnvByGeneTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }) {
           order="asc"
           query={BODY_QUERY.loc.source.body}
           variables={variables}
+          stickyHeader={true}
         />
       </Grid> 
     </Grid>

--- a/src/sections/common/OpenPedCanSomaticAlterations/CnvByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/CnvByGeneTab.js
@@ -77,7 +77,8 @@ function CnvByGeneTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }) {
           order="asc"
           query={BODY_QUERY.loc.source.body}
           variables={variables}
-          stickyHeader={true}
+          stickyHeader
+          noWrap={false}
         />
       </Grid> 
     </Grid>

--- a/src/sections/common/OpenPedCanSomaticAlterations/FusionByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/FusionByGeneTab.js
@@ -64,6 +64,7 @@ function FusionByGeneTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }
           order="asc"
           query={BODY_QUERY.loc.source.body}
           variables={variables}
+          stickyHeader={true}
         />
       </Grid> 
     </Grid>

--- a/src/sections/common/OpenPedCanSomaticAlterations/FusionByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/FusionByGeneTab.js
@@ -66,7 +66,8 @@ function FusionByGeneTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }
           order="asc"
           query={BODY_QUERY.loc.source.body}
           variables={variables}
-          stickyHeader={true}
+          stickyHeader
+          noWrap={false}
         />
       </Grid> 
     </Grid>

--- a/src/sections/common/OpenPedCanSomaticAlterations/FusionByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/FusionByGeneTab.js
@@ -4,11 +4,11 @@ import { Grid } from '@material-ui/core';
 import { DataTable } from '../../../components/Table';
 import { defaultRowsPerPageOptions } from '../../../constants';
 import  Link from '../../../components/Link';
-import { renderPMTLCell } from './utils';
+import { renderPMTLCell, addCustomFields } from './utils';
 import { genericComparator } from '../../../utils/comparators'
 
 // Configuration for how the tables will display the data
-const columns = [
+let columns = [
   { id: 'geneSymbol', label: 'Gene symbol',
       renderCell: ({ geneSymbol, targetFromSourceId }) => 
         <Link to={`/target/${targetFromSourceId}`}>{geneSymbol}</Link>
@@ -49,6 +49,8 @@ const dataDownloaderColumns = [
 ]
 
 function FusionByGeneTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }) {
+  // Set a minimum column width
+  addCustomFields(columns)
   return (
     <Grid container>
       <Grid item xs={12}>

--- a/src/sections/common/OpenPedCanSomaticAlterations/FusionTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/FusionTab.js
@@ -93,7 +93,8 @@ function FusionTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }) {
           order="asc"
           query={BODY_QUERY.loc.source.body}
           variables={variables}
-          stickyHeader={true}
+          stickyHeader
+          noWrap={false}
         />
       </Grid> 
     </Grid>

--- a/src/sections/common/OpenPedCanSomaticAlterations/FusionTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/FusionTab.js
@@ -91,6 +91,7 @@ function FusionTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }) {
           order="asc"
           query={BODY_QUERY.loc.source.body}
           variables={variables}
+          stickyHeader={true}
         />
       </Grid> 
     </Grid>

--- a/src/sections/common/OpenPedCanSomaticAlterations/FusionTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/FusionTab.js
@@ -4,11 +4,11 @@ import { Grid } from '@material-ui/core';
 import { DataTable } from '../../../components/Table';
 import { defaultRowsPerPageOptions } from '../../../constants';
 import  Link from '../../../components/Link';
-import { renderPMTLCell } from './utils';
+import { renderPMTLCell, addCustomFields } from './utils';
 import { genericComparator } from '../../../utils/comparators'
 
 // Configuration for how the tables will display the data
-const columns = [
+let columns = [
   { id: 'fusionName', label: 'Fusion Name', sortable:true },
   { id: 'fusionType', label: 'Fusion Type', sortable:true },
   { id: 'geneSymbol', label: 'Gene symbol',
@@ -76,6 +76,8 @@ const dataDownloaderColumns = [
 ]
 
 function FusionTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }) {
+  // Set a minimum column width
+  addCustomFields(columns)
   return (
     <Grid container>
       <Grid item xs={12}>

--- a/src/sections/common/OpenPedCanSomaticAlterations/SnvByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/SnvByGeneTab.js
@@ -4,7 +4,7 @@ import { Grid } from '@material-ui/core';
 import { DataTable } from '../../../components/Table';
 import { defaultRowsPerPageOptions } from '../../../constants';
 import  Link from '../../../components/Link';
-import { renderPMTLCell } from './utils'
+import { renderPMTLCell, addCustomFields } from './utils'
 import { genericComparator } from '../../../utils/comparators'
 
 const createExternalLink = (url, description) => {
@@ -13,7 +13,7 @@ const createExternalLink = (url, description) => {
 }
 
 // Configuration for how the tables will display the data
-const columns = [
+let columns = [
   {
     id: 'geneSymbol', label: 'Gene symbol',
     renderCell: ({ geneSymbol, targetFromSourceId }) => 
@@ -78,7 +78,8 @@ const dataDownloaderColumns = [
 ]
 
 function SnvByGeneTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }) {
-
+  // Set a minimum column width
+  addCustomFields(columns)
   return (
     <Grid container>
       <Grid item xs={12}>

--- a/src/sections/common/OpenPedCanSomaticAlterations/SnvByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/SnvByGeneTab.js
@@ -95,7 +95,8 @@ function SnvByGeneTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }) {
           order="asc"
           query={BODY_QUERY.loc.source.body}
           variables={variables}
-          stickyHeader={true}
+          stickyHeader
+          noWrap={false}
         />
       </Grid> 
     </Grid>

--- a/src/sections/common/OpenPedCanSomaticAlterations/SnvByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/SnvByGeneTab.js
@@ -94,6 +94,7 @@ function SnvByGeneTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }) {
           order="asc"
           query={BODY_QUERY.loc.source.body}
           variables={variables}
+          stickyHeader={true}
         />
       </Grid> 
     </Grid>

--- a/src/sections/common/OpenPedCanSomaticAlterations/SnvByVariantTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/SnvByVariantTab.js
@@ -4,11 +4,11 @@ import { Grid } from '@material-ui/core';
 import { DataTable } from '../../../components/Table';
 import { defaultRowsPerPageOptions } from '../../../constants';
 import  Link from '../../../components/Link';
-import { renderPMTLCell } from './utils';
+import { renderPMTLCell, addCustomFields} from './utils';
 import { genericComparator } from '../../../utils/comparators'
 
 // Configuration for how the tables will display the data
-const columns = [
+let columns = [
   {
     id: 'geneSymbol', label: 'Gene symbol',
     renderCell: ({ geneSymbol, targetFromSourceId }) => 
@@ -79,6 +79,8 @@ const dataDownloaderColumns = [
 ]
 
 function SnvByVariantTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }) {
+  // Set a minimum column width
+  addCustomFields(columns)
   return (
     <Grid container>
       <Grid item xs={12}>

--- a/src/sections/common/OpenPedCanSomaticAlterations/SnvByVariantTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/SnvByVariantTab.js
@@ -96,7 +96,8 @@ function SnvByVariantTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }
           order="asc"
           query={BODY_QUERY.loc.source.body}
           variables={variables}
-          stickyHeader={true}
+          stickyHeader
+          noWrap={false}
         />
       </Grid> 
     </Grid>

--- a/src/sections/common/OpenPedCanSomaticAlterations/SnvByVariantTab.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/SnvByVariantTab.js
@@ -94,6 +94,7 @@ function SnvByVariantTab({ data, BODY_QUERY, variables, dataDownloaderFileStem }
           order="asc"
           query={BODY_QUERY.loc.source.body}
           variables={variables}
+          stickyHeader={true}
         />
       </Grid> 
     </Grid>

--- a/src/sections/common/OpenPedCanSomaticAlterations/utils.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/utils.js
@@ -42,5 +42,7 @@ export const getSADefaultTab = (data) => {
 }
 
 export const addCustomFields = (columns, minWidth='160px') => {
-  columns.map((data, i) => columns[i] = data.minWidth ? data : {...data, minWidth: minWidth})
+  const labelStyle = {padding: '2px 10px 2px 2px'}
+  columns.map((data, i) => 
+    columns[i] = data.minWidth ? {...data, labelStyle} : {...data, minWidth: minWidth, labelStyle})
 }

--- a/src/sections/common/OpenPedCanSomaticAlterations/utils.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/utils.js
@@ -40,3 +40,7 @@ export const getSADefaultTab = (data) => {
   }
   return defaultTab;
 }
+
+export const addCustomFields = (columns, minWidth='160px') => {
+  columns.map((data, i) => columns[i] = data.minWidth ? data : {...data, minWidth: minWidth})
+}


### PR DESCRIPTION
In this PR:
- Sticky Header functionally has been added back to the Table component. Previously it has been added and removed from [OTP](https://github.com/opentargets/platform-app) here: 
  - https://github.com/opentargets/platform-app/pull/187
  - https://github.com/opentargets/platform-app/commit/243d8fe1bbc0f8326c193507abeebe678e1a6ba4
- All tables under OpenPedCan Somatic Alterations (SA) widget has been updated to include:
  -  Sticky Header functionality
  - Wrap row content 
  - Set a minimum column width of 160px 
  - Add Label Style to customize Table Header padding to reduce Table header height

Related Ticket: PPDC-384, PPDC-643


