### PR TITLE
PPDC-696 (Implement NCINavBar for smaller screen)

### DIFF
--- a/src/components/NCILogoBar/LogoBar.js
+++ b/src/components/NCILogoBar/LogoBar.js
@@ -44,6 +44,20 @@ const styles = ()=>({
       maxWidth: '460px',
       cursor: 'pointer',
       marginLeft: '45px',
+      float: 'left',
+      "@media (max-width: 1133px) and (min-width: 377px)":{
+        width: '405px',
+        marginLeft: '0px',
+      },
+      "@media (max-width: 376px) and (min-width: 340px)":{
+        width: '350px',
+        marginLeft: '10px',
+      },
+      "@media (max-width: 339px)":{
+        width: '295px',
+        marginLeft: '10px',
+      },
+
     };
     return Object.assign(defaultProps, props.customStyle.nihLogoImg);
   },

--- a/src/components/NCINavBar/LargerScreenNB.js
+++ b/src/components/NCINavBar/LargerScreenNB.js
@@ -13,7 +13,7 @@ import cn from '../helpers/classNameConcat';
 
 const drawerWidth = 240;
 
-const NavBar = ({
+const LargerScreenNB = ({
   classes, isSidebarOpened, navBarData, navBarstyling, numberOfCases, components = {},
 }) => {
   // Similar to componentDidMount and componentDidUpdate:
@@ -24,7 +24,6 @@ const NavBar = ({
   function handleButtonClickEvent(eventName) {
     setClickedEl(eventName);
   }
-
   
   function  getPCDNButton(navButton) {
     return (
@@ -243,10 +242,10 @@ const styles = () => ({
 
 });
 
-NavBar.defaultProps = {
+LargerScreenNB.defaultProps = {
   classes: {},
   navBarstyling: {},
 };
 
-const StyledNavBar = withStyles(styles)(NavBar);
+const StyledNavBar = withStyles(styles)(LargerScreenNB);
 export default StyledNavBar;

--- a/src/components/NCINavBar/NavBar.js
+++ b/src/components/NCINavBar/NavBar.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import SmallerScreenNB from './SmallerScreenNB';
-import LargerScreenNB from './NavBarView'
- 
-
+import LargerScreenNB from './LargerScreenNB'
 
 const NavBar = ({
   navBarData, navBarstyling, classes, isSidebarOpened, numberOfCases, components = {},

--- a/src/components/NCINavBar/NavBar.js
+++ b/src/components/NCINavBar/NavBar.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import SmallerScreenNB from './SmallerScreenNB';
+import LargerScreenNB from './NavBarView'
+ 
+
+
+const NavBar = ({
+  navBarData, navBarstyling, classes, isSidebarOpened, numberOfCases, components = {},
+}) => {
+  const [anchorEl, setAnchorEl] = React.useState(null)
+  const [innerWidth, setInnerWidth] = React.useState(window.innerWidth);
+  const [mobileView, setMobileView] = React.useState(false);
+  const SMALLER_SCREEN_BREAK_POINT = 1133
+
+  React.useEffect(() => {
+    const handleResize = () => {
+      setInnerWidth(window.innerWidth);
+      setMobileView(window.innerWidth < SMALLER_SCREEN_BREAK_POINT)
+    };
+
+    handleResize();
+    
+    window.addEventListener('resize', () => handleResize());
+    return () => {
+      window.removeEventListener('resize', () => handleResize());
+    };
+  }, []);
+
+  return (
+    mobileView 
+      ?   
+        <SmallerScreenNB  // NavBar for Smaller Screen (innerWidth < SMALLER_SCREEN_BREAK_POINT)
+          navBarData={navBarData}
+          navBarstyling={navBarstyling}
+          mobileView={mobileView}
+          setMobileView={setMobileView}
+          innerWidth={innerWidth}
+          setInnerWidth={setInnerWidth}
+          anchorEl={anchorEl}
+          setAnchorEl={setAnchorEl}/>
+      :   
+        <LargerScreenNB  // NavBar for Larger screen
+          navBarData={navBarData}
+          navBarstyling={navBarstyling}/>
+  )
+
+}
+
+export default NavBar;

--- a/src/components/NCINavBar/NavBarView.js
+++ b/src/components/NCINavBar/NavBarView.js
@@ -162,6 +162,10 @@ const styles = () => ({
     paddingRight: props.navBarstyling.global.paddingRight ? props.navBarstyling.global.paddingRight : '45px',
     paddingLeft: props.navBarstyling.global.paddingLeft ? props.navBarstyling.global.paddingLeft : '45px',
     alignItems: props.navBarstyling.global.alignItems ? props.navBarstyling.global.alignItems : 'flex-start',
+    "@media (max-width: 1223px)": {
+      paddingRight: 0,
+      paddingLeft: 0,
+    },
   }),
   buttonRoot: (props) => ({
     padding: '0px 28px 0px 29px',

--- a/src/components/NCINavBar/SmallerScreenNB.js
+++ b/src/components/NCINavBar/SmallerScreenNB.js
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import {
+  AppBar,
+  Toolbar,
+  withStyles,
+  Popover,
+  IconButton
+} from '@material-ui/core';
+import cn from '../helpers/classNameConcat';
+import { Menu } from '@material-ui/icons';
+import Close from '@material-ui/icons/Close';
+import { NavLink } from 'react-router-dom';
+
+const SmallerScreenNB = ({
+  classes, isSidebarOpened, navBarData, navBarstyling, innerWidth, anchorEl, setAnchorEl
+}) => {
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'mobileExpandedViewMenu' : undefined;
+  
+  return (
+    <>
+ 
+      <AppBar
+      position="relative"
+      className={cn(classes.appBar, {
+        [classes.appBarShift]: isSidebarOpened,
+      })}
+      >
+        <Toolbar className={classes.mobileToolbar}>
+          <IconButton
+            aria-describedby={id}
+            onClick={open ? handleClose : handleClick}
+          >
+            {open ? <Close className={classes.mobileIcon}/> : <Menu className={classes.mobileIcon}/> }
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorReference="anchorPosition"
+        elevation={1}
+        marginThreshold={0}
+        anchorPosition={{ top: 185, left: 0 }}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        PaperProps={{
+          style: {
+            boxShadow: 'none',
+            width: innerWidth,
+            maxWidth: innerWidth,
+          },
+        }} 
+        className={classes.PopoverStyle}
+      >
+        <div>
+          <ul className={classes.ulStyle}>
+            {
+              navBarData.slice(0, navBarData.length).map( (navItem, index) => ( 
+                navItem.type === "dropdown" 
+                ? 
+                  <>
+                    <li className={classes.liStyle} key={index}>
+                      <NavLink to={navItem.link} onClick={handleClose} className={classes.navLink}>
+                        {navItem.labelText}
+                      </NavLink>
+                    </li>
+                    <ul className={classes.ulStyle}>
+                      {navItem.dropDownLinks.slice(0, navItem.dropDownLinks.length).map((dropDownNavItem, dIndex) => 
+                        (
+                          <li className={classes.liStyle} key={index + '_' + dIndex}>
+                            <NavLink to={dropDownNavItem.link} onClick={handleClose} className={classes.navLink}>
+                              <span className={classes.greaterSign}>{'>'}</span> {dropDownNavItem.labelText}
+                            </NavLink>
+                          </li>
+                        )
+                      )}
+                    </ul>
+                  </>
+                : 
+                  <li className={classes.liStyle} key={index}>
+                    <NavLink to={navItem.link} onClick={handleClose} className={classes.navLink}>
+                      {navItem.labelText}
+                    </NavLink>
+                  </li>
+              ))
+            }
+          </ul>
+        </div>
+      </Popover>
+    </>
+  )
+}
+
+const styles = () => ({
+  appBar: (props) => ({
+    backgroundColor: props.navBarstyling.global.backgroundColor ? props.navBarstyling.global.backgroundColor : '#142D64',
+    width: '100vw',
+    boxShadow: 'none',
+
+  }),
+  mobileToolbar: (props) => ({
+    minHeight: props.navBarstyling.global.height ? props.navBarstyling.global.height : '59px',
+    paddingLeft: '31px',
+  }),
+  ulStyle: {
+    margin: '0',
+    padding: '0',
+    width: '100%',
+    fontSize: '22px',
+    fontFamily: 'Nunito Sans',
+    listStyle: 'none',
+  },
+  liStyle: {
+    display: 'block',
+    textDecoration: 'none',
+  },
+  mobileIcon: {
+    color: 'white',
+    fontSize: '40px'
+  },
+  navLink: {
+    display: 'block',
+    minHeight: '53px',
+    textDecoration: 'none',
+    backgroundColor: '#005BA0',
+    color: '#FFFFFF',
+    padding: '10px 31px',
+    borderBottom: '1px solid #2488D4',
+    '&:hover': {
+      backgroundColor: 'white',
+      color: "#0B3557",
+      fontWeight: 'bold',
+    }
+  },
+  greaterSign: {
+    padding: '0 10px 0 15px',
+  }
+})
+
+SmallerScreenNB.defaultProps = {
+  classes: {},
+  navBarstyling: {},
+};
+
+const StyledNavBar = withStyles(styles)(SmallerScreenNB);
+export default StyledNavBar;

--- a/src/components/NCINavBar/index.js
+++ b/src/components/NCINavBar/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import NavBar from './NavBarView';
+import NavBar from './NavBar';
 
 export const navBarstyling = {
   global: {
@@ -63,6 +63,7 @@ export const navBarData = [
   {
     labelText: 'About Molecular Targets',
     type: 'dropdown',
+    link: '/about',
     dropDownLinks:[
     {
       labelText: 'About Molecular Targets',

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -12,7 +12,7 @@ const styles = theme => ({
     backgroundColor: theme.palette.primary.main,
     margin: 0,
     width: '100%',
-    zIndex: 40002,
+    zIndex: 1002,
     top: 184, // NCINavBar take 59 px
   },
   navbarHomepage: {

--- a/src/components/NavPanel/navPanelStyles.js
+++ b/src/components/NavPanel/navPanelStyles.js
@@ -23,7 +23,7 @@ const navPanelStyles = makeStyles(theme => ({
     ...theme.Drawer.paper,
     overflow: 'hidden',
     width: 'inherit',
-    zIndex: 40001,
+    zIndex: theme.zIndex.navPanel,
     '&:hover': {
       boxShadow:
         '0px 8px 10px -5px rgba(0,0,0,0.2), 0px 16px 24px 2px rgba(0,0,0,0.14), 0px 6px 30px 5px rgba(0,0,0,0.12)',

--- a/src/theme.js
+++ b/src/theme.js
@@ -143,6 +143,9 @@ const theme = {
       height: 'calc(100% - 232px)',
     }
   },
+  zIndex: {
+    navPanel: 1001
+  }
 };
 
 export default theme;

--- a/src/theme.js
+++ b/src/theme.js
@@ -144,7 +144,8 @@ const theme = {
     }
   },
   zIndex: {
-    navPanel: 1001
+    navBar: 1002,
+    navPanel: 1001,
   }
 };
 


### PR DESCRIPTION
In this PR:
- Add NavBar for smaller Screen. Since MTP NavBar hold menu Item that has multiple words the break point for the new Nav Bar view will start at 1133 px.
- Refactor the structure of the NCINavBar component.
- reduce zIndex for NavPanel and blue NavBar

Related Ticket: PPDC-695, PPDC-696, PPDC-636 