### PR TITLE
remove stickyheader for KnownDrugs widgets

### DIFF
--- a/src/sections/common/KnownDrugs/Body.js
+++ b/src/sections/common/KnownDrugs/Body.js
@@ -262,7 +262,6 @@ function Body({
       renderBody={() => (
         <Table
           loading={loading}
-          stickyHeader
           showGlobalFilter
           globalFilter={globalFilter}
           dataDownloader


### PR DESCRIPTION
In this PR:
- Sticky Header functionality has been removed from `KnownDrugs` widgets.
- At the moment, only `OpenPedCan Somatic Alterations` widgets has the Sticky header functionality. 
