### PR TITLE
PPDC-705 (Mobile responsiveness for Change Log page)

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -315,5 +315,5 @@ export const version = {
   frontendURL: "https://github.com/CBIIT/ppdc-otp-frontend/releases",
   backend: config.backendVersion,
   backendURL: "https://github.com/CBIIT/ppdc-otp-backend/releases",
-  changeLogSection: " /about#changeLog"
+  changeLogPage: "/change-log"
 }

--- a/src/pages/ChangeLogPage/ChangeLogView.js
+++ b/src/pages/ChangeLogPage/ChangeLogView.js
@@ -36,11 +36,6 @@ const useStyles = makeStyles(theme => ({
       padding:'55px 0px 0px 0px',
     }
   },
-  container: {
-    margin: '58px 0 0px 0',
-    fontSize: '16px'
-  },
-   
   changeLogPaper: {
     marginBottom: '8px',
     borderRadius: '8px',
@@ -50,26 +45,14 @@ const useStyles = makeStyles(theme => ({
     border: '1px solid #2188D8', 
     borderRadius: '6px'
   },
-
   changeLogBoxLeft:{
-    flex: 1, padding: '12px 17px 17px 14px' 
+    flex: 1, 
+    padding: '12px 17px 17px 14px' 
   },
-
   changeLogBoxRight:{
     flex: 1,
     padding: '12px 17px 17px 14px',
     borderLeft: '1px solid #2188D8' 
-  },
-
-  base: {
-    fontSize: 'inherit',
-    textDecoration: 'none',
-  },
-  baseDefault: {
-    color: theme.palette.primary.main,
-    '&:hover': {
-      color: theme.palette.primary.dark,
-    },
   },
 }));
 

--- a/src/pages/ChangeLogPage/ChangeLogView.js
+++ b/src/pages/ChangeLogPage/ChangeLogView.js
@@ -20,14 +20,21 @@ import usePlatformApi from '../../hooks/usePlatformApi';
 
 const useStyles = makeStyles(theme => ({
   changeLogContainer: {
+    minWidth: '320px',
     marginTop: '80px',
     backgroundColor: '#EDF1F4',
     color: '#000000',
     fontSize: '16px',
     padding:'125px 40px 68px 40px',
+    '@media (max-width: 360px)': {
+      padding:'125px 15px 68px 15px',
+    },
   },
   changeLogSubContainer: {
     padding:'55px 40px 0px 40px',
+    '@media (max-width: 460px)': {
+      padding:'55px 0px 0px 0px',
+    }
   },
   container: {
     margin: '58px 0 0px 0',
@@ -83,7 +90,7 @@ const AboutView = ({ data }) => {
     <NCIHeader/>
 
     <Grid container justify="center" className={classes.changeLogContainer}>
-      <Grid item xs={10} md={8} lg={7} xl={6} className={classes.introContainer}>
+      <Grid item xs={12} md={8} lg={7} xl={6} className={classes.introContainer}>
 
         <Typography variant="h4" component="h1" align="center" paragraph className={classes.title}>
           Change Log

--- a/src/pages/ChangeLogPage/ChangeLogView.js
+++ b/src/pages/ChangeLogPage/ChangeLogView.js
@@ -59,7 +59,7 @@ const useStyles = makeStyles(theme => ({
 const AboutView = ({ data }) => {
   const request = usePlatformApi()
   const classes = useStyles();
-  const appTitle = "About Page";
+  const appTitle = "Change Log";
   const BEversion =
       request.loading ? "Loading..." : request.data?.meta?.mtpVersion?.version || version.backend
 

--- a/src/pages/ChangeLogPage/ChangeLogView.js
+++ b/src/pages/ChangeLogPage/ChangeLogView.js
@@ -20,20 +20,20 @@ import usePlatformApi from '../../hooks/usePlatformApi';
 
 const useStyles = makeStyles(theme => ({
   changeLogContainer: {
-    minWidth: '320px',
+    minWidth: '340px',
     marginTop: '80px',
     backgroundColor: '#EDF1F4',
     color: '#000000',
     fontSize: '16px',
     padding:'125px 40px 68px 40px',
     '@media (max-width: 360px)': {
-      padding:'125px 15px 68px 15px',
+      padding:'125px 28px 68px 28px',
     },
   },
   changeLogSubContainer: {
     padding:'55px 40px 0px 40px',
     '@media (max-width: 460px)': {
-      padding:'55px 0px 0px 0px',
+      padding:'30px 0px 0px 0px',
     }
   },
   changeLogPaper: {

--- a/src/pages/HomePage/Version.js
+++ b/src/pages/HomePage/Version.js
@@ -42,7 +42,7 @@ function VersionContainer({ children }) {
 function VersionLink() {
   return (
     <Box ml={1}>
-      <Link external to={version.changeLogSection}>
+      <Link external to={version.changeLogPage}>
          {version.frontend}
       </Link>
     </Box>


### PR DESCRIPTION
In this PR:
- Reduce margin and padding under Change log page to provide space for smaller screen size
- Update page title from `About Page` to `Change Log`
- Update Link URL that point from `Home>Search Box>version` to `Change Log `page
- Remove unused style

Related Ticket: PPDC-705