### PR TITLE
PPDC-700 (Fix: reduce large Header Icon)

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -12,11 +12,12 @@ const useStyles = makeStyles(theme => ({
   },
   mainIconContainer: {
     width: '56px',
-    textAlign: 'center',
+    display: 'flex',
+    alignItems: 'center',
     marginRight: '4px',
+    justifyContent: 'center',
   },
   mainIcon: {
-    height: '65px',
     color: theme.palette.primary.main,
   },
   subtitle: {


### PR DESCRIPTION
In this PR:
- The size of the main Icon located under header section for Target, Disease and Drug Page has been reduce to fix the sudden enlargement of the Icon.
-  Icon also has been center align, horizontally and vertically

Related Ticket: PPDC-700