### PR TITLE
PPDC-695-fix: (Fix: Align LogoBar and Hamburger menu Icon)

### DIFF
--- a/src/components/NCILogoBar/LogoBar.js
+++ b/src/components/NCILogoBar/LogoBar.js
@@ -45,17 +45,25 @@ const styles = ()=>({
       cursor: 'pointer',
       marginLeft: '45px',
       float: 'left',
-      "@media (max-width: 1133px) and (min-width: 377px)":{
+      "@media (max-width: 1133px)":{
         width: '405px',
-        marginLeft: '0px',
+        marginLeft: '-3px',
       },
-      "@media (max-width: 376px) and (min-width: 340px)":{
+      "@media (max-width: 400px)":{
         width: '350px',
         marginLeft: '10px',
       },
-      "@media (max-width: 339px)":{
-        width: '295px',
-        marginLeft: '10px',
+      "@media (max-width: 355px)":{
+        width: '300px',
+        marginLeft: '11px',
+      },
+      "@media (max-width: 310px)":{
+        width: '260px',
+        marginLeft: '12px',
+      },
+      "@media (max-width: 274px)":{
+        width: '230px',
+        marginLeft: '15px',
       },
 
     };

--- a/src/pages/HomePage/HomeBox.js
+++ b/src/pages/HomePage/HomeBox.js
@@ -5,6 +5,10 @@ import NavIcon from '../../assets/PediatricDataCancer-MenuBar-Icon.svg'
 const useStyles = makeStyles(theme => ({
   gridContainer: {
     padding: '0 28px',
+    marginTop: '100px',
+    '@media (min-width: 600px)': {
+      padding: '0px',
+    },
   },
   homeboxContainer: {
     overflow: 'visible',

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -24,6 +24,9 @@ import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 
 
 const useStyles = makeStyles(theme => ({
+  homeBox: {
+    minHeight: '800px',
+  },
   links: {
     marginTop: '12px',
   },

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -25,7 +25,7 @@ import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 
 const useStyles = makeStyles(theme => ({
   homeBox: {
-    minHeight: '800px',
+    minHeight: '700px',
   },
   links: {
     marginTop: '12px',

--- a/src/pages/HomePage/Splash.js
+++ b/src/pages/HomePage/Splash.js
@@ -16,7 +16,7 @@ const styles = theme => ({
     backgroundColor: theme.palette.primary.main,
     width: '100%',
     height: '100%',
-    minHeight: '800px',
+    minHeight: '700px',
     zIndex: -1,
   },
 });

--- a/src/pages/HomePage/Splash.js
+++ b/src/pages/HomePage/Splash.js
@@ -16,6 +16,7 @@ const styles = theme => ({
     backgroundColor: theme.palette.primary.main,
     width: '100%',
     height: '100%',
+    minHeight: '800px',
     zIndex: -1,
   },
 });


### PR DESCRIPTION
in this PR:
- LogoBar and Hamburger/close menu Icon has been closely aligned. 
- Search Box under Home page has a marginTop of 100px, to avoid overlap issue by Header
- Home Page now has Minimum Height of 700px in order to properly display the search box and splash for smaller screen size.

Related Ticket: PPDC-695