### PR TITLE
Update the efo yaml to lock down to the version 22.04

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,7 @@ const config = {
   googleTagManagerID: window.injectedEnv.configGoogleTagManagerID ?? null,
   efoURL:
     window.injectedEnv.configEFOURL ??
-    'https://platform.opentargets.org/data/ontology/efo_json/diseases_efo.jsonl',
+    'https://raw.githubusercontent.com/CBIIT/mtp-config/main/front-end/ontology-inputs/22.04/diseases_efo.jsonl',
   
   primaryColor: window.injectedEnv.configPrimaryColor ?? '#3489ca',
   chopRServer: window.injectedEnv.chopRServer ?? 'https://openpedcan-api.d3b.io',


### PR DESCRIPTION
Update the efo yaml to lock down to the version 22.04. Current efo yaml based on the verion 22.06 which  break some functions on our site. Downgrade to 22.04 can solve some issues founded. 