### PR TITLE
PPDC-704-fix: refactor style for smaller screen size 

### DIFF
--- a/src/components/NCINavBar/SmallerScreenNB.js
+++ b/src/components/NCINavBar/SmallerScreenNB.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { Fragment } from 'react';
 import {
   AppBar,
   Toolbar,
@@ -73,7 +73,7 @@ const SmallerScreenNB = ({
               navBarData.slice(0, navBarData.length).map( (navItem, index) => ( 
                 navItem.type === "dropdown" 
                 ? 
-                  <>
+                  <Fragment key={"fragment" + index}>
                     <li className={classes.liStyle} key={index}>
                       <NavLink to={navItem.link} onClick={handleClose} className={classes.navLink}>
                         {navItem.labelText}
@@ -90,7 +90,7 @@ const SmallerScreenNB = ({
                         )
                       )}
                     </ul>
-                  </>
+                  </Fragment>
                 : 
                   <li className={classes.liStyle} key={index}>
                     <NavLink to={navItem.link} onClick={handleClose} className={classes.navLink}>

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -142,6 +142,12 @@ const useStyles = makeStyles(theme => ({
       color: theme.palette.primary.dark,
     },
   },
+  contactEmail: {
+    // In order to fit long character of email 
+    '@media (max-width: 450px)': {
+      fontSize: '11px'
+    },
+  }
 }));
 
 const AboutView = ({ data }) => {
@@ -554,10 +560,10 @@ const AboutView = ({ data }) => {
          
              
               As the CCDI continues to refine the Molecular Targets Platform, input from the community is highly valued to help improve usability. Please send your feedback and comments to 
-               {' '} 
-               <a className={classNames(classes.base, classes.baseDefault)} href={contactEmail}>
+               {' '}
+               <a className={classNames(classes.base, classes.baseDefault, classes.contactEmail)} href={contactEmail}>
                  {contact.email}
-              </a> .
+              </a>&nbsp;.
             </Typography>
 
           </Grid>
@@ -580,7 +586,7 @@ const AboutView = ({ data }) => {
 
             </Typography>
             
-            <Grid item container direction="row" alignItems="center" className={classes.infographicContainer}>
+            <Grid item container direction="row" alignItems="center" justify="center" className={classes.infographicContainer}>
                 <Grid item>
                   <img src={Infographic} alt="Infographic of Molecular Targets Platform"/>
                 </Grid>

--- a/src/pages/PMTLDocPage/index.js
+++ b/src/pages/PMTLDocPage/index.js
@@ -27,6 +27,8 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.primary.main,
   },
   table: {
+    display: 'block',
+    overflowX: 'auto',
     'border-collapse': 'collapse',
     width: '100%',
   },
@@ -40,6 +42,16 @@ const useStyles = makeStyles(theme => ({
     textAlign: 'left',
     padding: '8px',
   },
+  scroll: {
+    overflowX: 'scroll' 
+  },
+  fdaPmtlColumnsPapper: {
+    minWidth: '400px'
+  },
+  mappingDescriptionPapper: {
+    minWidth: '500px'
+  },
+ 
 }));
 
 function PMTLDocPage() {
@@ -398,8 +410,8 @@ function PMTLDocPage() {
               </Link>.
             </Typography>
           </Grid>
-          <Grid item xs={12}>
-            <Paper variant="outlined" elevation={0}>
+          <Grid item xs={12} className={classes.scroll}>
+            <Paper variant="outlined" elevation={0} className={classes.fdaPmtlColumnsPapper}>
               {displayTable(fdaPmtlColumns)}
             </Paper>
           </Grid>
@@ -420,8 +432,8 @@ function PMTLDocPage() {
               and standardize symbol”).
             </Typography>
           </Grid>
-          <Grid item xs={12}>
-            <Paper variant="outlined" elevation={0}>
+          <Grid item xs={12} className={classes.scroll}>
+            <Paper variant="outlined" elevation={0} className={classes.mappingDescriptionPapper}>
               {displayTable(mappingDescription)}
             </Paper>
           </Grid>


### PR DESCRIPTION
In this PR:
- "infographic" under About page is centered
- contact email "ncichildhoodcancerdatainitiative@mail.nih.gov" and "." are wrapped. Since the email has a lot of character, the font size has been decreased to 11px for ViewPort of < 450px
- Fix NavBar warning
- Update  the two table under FDA PMTL Doc page with a minimum width and auto scroll to allow mobile responsiveness

Related Ticket: PPDC-704