### PR TITLE
PPDC-749

### DIFF
--- a/src/components/BasePageMTP.js
+++ b/src/components/BasePageMTP.js
@@ -20,8 +20,8 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
   },
   gridContainer: {
-    margin: '190px 0 0 0',
-    padding: '24px',
+    margin: `${theme.header.height} 0px 0px 0px`,
+    padding: '40px 16px 24px',
     width: '100%',
     flex: '1 0 auto',
   },

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -21,14 +21,15 @@ import UnspecifiedIcon from '../../components/RMTL/UnspecifiedIcon';
 import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 import Infographic from '../../assets/about/Infographic.png';
 import classNames from 'classnames';
+import cn from '../../components/helpers/classNameConcat';
 
 const useStyles = makeStyles(theme => ({
   paper: {
     padding: '0 0 100px 0',
   },
   molecularTargetC: {
-    margin: '160px 0 0 0',
-    padding: '48px 0 56px 0',
+    margin: `${theme.header.height} 0px 0px`,
+    padding: `${theme.header.spacing} 0px 56px`,
     backgroundColor: '#CDE9FF',
     fontSize: '16px'
   },
@@ -48,6 +49,9 @@ const useStyles = makeStyles(theme => ({
     fontFamily: 'Inter',
     fontSize: '34px',
     fontWeight: '600',
+  },
+  'firstTitle': {
+    marginTop: '0px',
   },
   boxTitle: {
     marginBottom: '34px',
@@ -525,8 +529,13 @@ const AboutView = ({ data }) => {
         {/* The Molecular Targets Platform */}
         <Grid container justify="center" className={classes.molecularTargetC}>
           <Grid item xs={10} md={8} lg={7} xl={6} className={classes.introContainer}>
-
-            <Typography variant="h4" component="h1" align="center" paragraph className={classes.title}>
+            <Typography 
+              variant="h4"
+              component="h1"
+              align="center"
+              paragraph
+              className={classNames(classes.title, classes.firstTitle)}
+            >
               The Molecular Targets Platform
             </Typography>
 

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -21,7 +21,6 @@ import UnspecifiedIcon from '../../components/RMTL/UnspecifiedIcon';
 import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 import Infographic from '../../assets/about/Infographic.png';
 import classNames from 'classnames';
-import cn from '../../components/helpers/classNameConcat';
 
 const useStyles = makeStyles(theme => ({
   paper: {

--- a/src/pages/ChangeLogPage/ChangeLogView.js
+++ b/src/pages/ChangeLogPage/ChangeLogView.js
@@ -21,13 +21,13 @@ import usePlatformApi from '../../hooks/usePlatformApi';
 const useStyles = makeStyles(theme => ({
   changeLogContainer: {
     minWidth: '340px',
-    marginTop: '80px',
     backgroundColor: '#EDF1F4',
     color: '#000000',
     fontSize: '16px',
-    padding:'125px 40px 68px 40px',
+    marginTop: theme.header.height,
+    padding: `${theme.header.spacing} 40px 68px`,
     '@media (max-width: 360px)': {
-      padding:'125px 28px 68px 28px',
+      padding: `${theme.header.spacing} 28px 68px`,
     },
   },
   changeLogSubContainer: {

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -175,6 +175,10 @@ const useStyles = makeStyles(theme => ({
   maxContainerWidth: {
     maxWidth: '900px'
   },
+  infoList: {
+    marginLeft: '14px',
+    padding: 0,
+  },
 
   /*****          result          *****/
   result: {
@@ -412,7 +416,7 @@ function CHoPPage() {
                 <Typography component="p" align='center' paragraph>
                   In the resulting table:
                 </Typography>
-                <ul>
+                <ul className={classes.infoList}>
                   <li>
                     Each <b> Evidence </b> page link opens a page presenting all available data within the Molecular Targets 
                     Platform including available pediatric cancer data associating the specific target with the specific disease

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -109,8 +109,8 @@ const useStyles = makeStyles(theme => ({
     flex: '1 0 auto',
   },
   gridContainer: {
-    margin: '160px 0 0 0',
-    padding: '50px 28px 60px 28px',
+    margin: `${theme.header.height} 0 0 0`,
+    padding: `${theme.header.spacing} 28px 60px`,
     color: darkerBlueColor,
     backgroundColor: generalBackGroundColor,
     fontSize: '16px'

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -214,9 +214,6 @@ const useStyles = makeStyles(theme => ({
     }
   },
   "@media (max-width: 650px)": {
-    headerContainer: {
-      marginTop: '30px'
-    },
     searchContainer: {
       minWidth: '300px'
     },

--- a/src/theme.js
+++ b/src/theme.js
@@ -146,6 +146,10 @@ const theme = {
   zIndex: {
     navBar: 1002,
     navPanel: 1001,
+  },
+  header: {
+    height: '159px', // 100px for NCILogoBar and 59px for NCINavBar
+    spacing: '52px' // spacing below the header
   }
 };
 


### PR DESCRIPTION
In this PR:
- Left Indent beside the `ul` tag has been removed under PCDN page
- Adjust the space between header and body content to be approx. 52px for About, Change log, PCDN, FDA PMTL Landing and Document pages.

Related Ticket: PPDC-749