### PR TITLE
CCDIMTP-49

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,7 @@ class App extends Component {
                 <Route path="/About" component={AboutPage} />
                 <Route path="/fda-pmtl" component={PMTLPage} />
                 <Route path="/change-log" component={ChangeLog} />
-                <Route path="/fda-pmtl-docs" component={PMTLDocPage} />
+                <Route path="/mtp-pmtl-docs" component={PMTLDocPage} />
                 <Route
                   path="/pediatric-cancer-data-navigation"
                   component={PedCancerDataNavPage}

--- a/src/components/NCINavBar/index.js
+++ b/src/components/NCINavBar/index.js
@@ -66,7 +66,7 @@ export const navBarData = [
       },
       {
         labelText: 'MTP PMTL Documentation',
-        link: '/fda-pmtl-docs',
+        link: '/mtp-pmtl-docs',
       },
     ],
   },

--- a/src/components/NCINavBar/index.js
+++ b/src/components/NCINavBar/index.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import NavBar from './NavBar';
+import { mtpPageNames } from '../../constants';
+
+const { fdaPmtlPage, mtpPmtlDocPage } = mtpPageNames;
 
 export const navBarstyling = {
   global: {
@@ -56,17 +59,17 @@ export const navBarData = [
     link: '/',
   },
   {
-    labelText: 'FDA Pediatric Molecular Target Lists',
+    labelText: fdaPmtlPage.label,
     type: 'dropdown',
-    link: '/fda-pmtl',
+    link: fdaPmtlPage.url,
     dropDownLinks: [
       {
-        labelText: 'FDA Pediatric Molecular Target Lists',
-        link: '/fda-pmtl',
+        labelText: fdaPmtlPage.label,
+        link: fdaPmtlPage.url,
       },
       {
-        labelText: 'MTP PMTL Documentation',
-        link: '/mtp-pmtl-docs',
+        labelText: mtpPmtlDocPage.label,
+        link: mtpPmtlDocPage.url,
       },
     ],
   },

--- a/src/components/NCINavBar/index.js
+++ b/src/components/NCINavBar/index.js
@@ -65,7 +65,7 @@ export const navBarData = [
         link: '/fda-pmtl',
       },
       {
-        labelText: 'Documentation',
+        labelText: 'MTP PMTL Documentation',
         link: '/fda-pmtl-docs',
       },
     ],

--- a/src/components/RMTL/RMTLPopover.js
+++ b/src/components/RMTL/RMTLPopover.js
@@ -3,6 +3,7 @@ import { Grid, makeStyles, Typography } from '@material-ui/core';
 import { Tab, Tabs } from '@material-ui/core';
 import Popover from '@material-ui/core/Popover';
 
+import { mtpPageNames } from '../../constants';
 import Link from '../Link';
 import RelevantIcon from './RelevantIcon';
 import NonRelevantIcon from './NonRelevantIcon';
@@ -76,7 +77,7 @@ function RMTLPopOver({ otherStyle, pmtl }) {
 
   const open = Boolean(anchorEl);
   const id = open ? 'simple-popover' : undefined;
-  const PMTLlandingPageUrl = '/fda-pmtl';
+  const { fdaPmtlPage } = mtpPageNames;
 
   const handleClick = event => {
     setAnchorEl(event.currentTarget);
@@ -131,7 +132,7 @@ function RMTLPopOver({ otherStyle, pmtl }) {
               <div className={classes.toLandingPageLinkBox}>
                 <span className={classes.toLandingPageLink}>
                   Search the PMTL within Molecular Targets{' '}
-                  <Link to={PMTLlandingPageUrl}>here</Link>
+                  <Link to={fdaPmtlPage.url}>here</Link>
                 </span>
               </div>
             </Tabs>

--- a/src/constants.js
+++ b/src/constants.js
@@ -317,3 +317,16 @@ export const version = {
   backendURL: 'https://github.com/CBIIT/ppdc-otp-backend/releases',
   changeLogPage: '/change-log',
 };
+
+export const mtpPageNames = {
+  // FDA Pediatric Molecular Target Lists
+  fdaPmtlPage: {
+    label: 'FDA Pediatric Molecular Target Lists',
+    url: '/fda-pmtl',
+  },
+  // MTP PMTL Documentation 
+  mtpPmtlDocPage: {
+    label: 'MTP PMTL Documentation',
+    url: '/fda-pmtl-docs',
+  },
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -88,7 +88,7 @@ export const mainMenuItems = config.profile.mainMenuItems ?? [
   // RMTL Doc
   {
     name: 'FDA PMTL Documentation',
-    url: '/fda-pmtl-docs',
+    url: '/mtp-pmtl-docs',
     external: false,
   },
   // FDA RMTL
@@ -327,6 +327,6 @@ export const mtpPageNames = {
   // MTP PMTL Documentation 
   mtpPmtlDocPage: {
     label: 'MTP PMTL Documentation',
-    url: '/fda-pmtl-docs',
+    url: '/mtp-pmtl-docs',
   },
 };

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -152,7 +152,7 @@ const useStyles = makeStyles(theme => ({
 const AboutView = ({ data }) => {
   const classes = useStyles();
   const appTitle = 'About Page';
-  const { fdaPmtlPage } = mtpPageNames;
+  const { fdaPmtlPage, mtpPmtlDocPage } = mtpPageNames;
   const [showHide, setShowHide] = useState({
     fdaPmtlDS: true,
     openPedCanDS: false,
@@ -230,8 +230,8 @@ const AboutView = ({ data }) => {
           interpretation of these lists in order to better inform decisions and
           improve treatments for childhood cancers. To read more about the
           implementation of the FDA PMTL within the Molecular Targets Platform,
-          read our detailed
-          <Link to="/fda-pmtl-docs"> FDA PMTL Documentation.</Link>
+          read our detailed{' '}
+          <Link to={mtpPmtlDocPage.url}>{mtpPmtlDocPage.label}</Link>.
         </p>
         <p>
           SOURCE:

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -2,17 +2,17 @@ import React, { useState } from 'react';
 import { Grid, makeStyles, Typography } from '@material-ui/core';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
 import { Helmet } from 'react-helmet';
+import classNames from 'classnames';
 import NCIFooter from '../../components/NCIFooter';
 import NCIHeader from '../../components/NCIHeader';
 import ScrollToTop from '../../components/ScrollToTop';
 import Link from '../../components/Link';
-import { appDescription, appCanonicalUrl, contact } from '../../constants';
+import { appDescription, appCanonicalUrl, contact, mtpPageNames } from '../../constants';
 import RelevantIcon from '../../components/RMTL/RelevantIcon';
 import NonRelevantIcon from '../../components/RMTL/NonRelevantIcon';
 import UnspecifiedIcon from '../../components/RMTL/UnspecifiedIcon';
 import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 import Infographic from '../../assets/about/Infographic.png';
-import classNames from 'classnames';
 
 const useStyles = makeStyles(theme => ({
   paper: {
@@ -152,6 +152,7 @@ const useStyles = makeStyles(theme => ({
 const AboutView = ({ data }) => {
   const classes = useStyles();
   const appTitle = 'About Page';
+  const { fdaPmtlPage } = mtpPageNames;
   const [showHide, setShowHide] = useState({
     fdaPmtlDS: true,
     openPedCanDS: false,
@@ -244,7 +245,7 @@ const AboutView = ({ data }) => {
           </Link>
           <br />
           Where this data is used in the MTP:
-          <Link to="/fda-pmtl"> FDA PMTL Landing Page</Link>
+          <Link to={fdaPmtlPage.url}> {fdaPmtlPage.label} </Link>
           <br />
         </p>
       </div>
@@ -459,7 +460,7 @@ const AboutView = ({ data }) => {
           <ul>
             <li>
               Browse the dedicated{' '}
-              <Link to="/fda-pmtl"> FDA PMTL Landing Page </Link> to find
+              <Link to={fdaPmtlPage.url}> {fdaPmtlPage.label} </Link> to find
               Targets and see FDA details
             </li>
             <li>

--- a/src/pages/ChangeLogPage/ChangeLogView.js
+++ b/src/pages/ChangeLogPage/ChangeLogView.js
@@ -8,6 +8,7 @@ import Link from '../../components/Link';
 import { appDescription, appCanonicalUrl, version } from '../../constants';
 import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 import usePlatformApi from '../../hooks/usePlatformApi';
+import { mtpPageNames } from '../../constants';
 
 const useStyles = makeStyles(theme => ({
   changeLogContainer: {
@@ -54,6 +55,7 @@ const AboutView = ({ data }) => {
   const BEversion = request.loading
     ? 'Loading...'
     : request.data?.meta?.mtpVersion?.version || version.backend;
+  const { mtpPmtlDocPage } = mtpPageNames;
 
   return (
     <>
@@ -247,7 +249,7 @@ const AboutView = ({ data }) => {
                   </Typography>
                   <b>Version in use</b>: v1.1 (Released 2021-09-09) <br />
                   <b>Detailed Change Log</b>:
-                  <Link to="/fda-pmtl-docs"> FDA PMTL Documentation</Link>
+                  <Link to={mtpPmtlDocPage.url}> {mtpPmtlDocPage.label} </Link>
                 </div>
 
                 <div className={classes.changeLogBoxRight}>

--- a/src/pages/PMTLDocPage/index.js
+++ b/src/pages/PMTLDocPage/index.js
@@ -5,6 +5,7 @@ import BasePageMTP from '../../components/BasePageMTP';
 import Link from '../../components/Link';
 import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 import ScrollToTop from '../../components/ScrollToTop';
+import { mtpPageNames } from '../../constants';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -67,7 +68,7 @@ function PMTLDocPage() {
     'https://useast.ensembl.org/info/genome/stable_ids/index.html#:~:text=Stable%20identifiers%20are%20ways%20that,and%20consistent%20across%20Ensembl%20releases';
   const hugoHgncLink = 'https://www.genenames.org/download/custom/';
 
-  const fdaPMTL = '/fda-pmtl';
+  const { fdaPmtlPage } = mtpPageNames;
 
   const fdaPmtlColumns = {
     tableHeader: ['Column Header', 'Example Value', 'Description'],
@@ -230,8 +231,8 @@ function PMTLDocPage() {
             </Typography>
             <Typography paragraph>
               Browse the
-              <Link to={fdaPMTL}>
-                <b> FDA PMTL Landing Page </b>
+              <Link to={fdaPmtlPage.url}>
+                <b> {fdaPmtlPage.label} </b>
               </Link>
               to identify pediatric molecular targets within the Molecular
               Targets Platform.
@@ -382,14 +383,14 @@ function PMTLDocPage() {
 
           <Grid item xs={12}>
             <Typography paragraph>
-              Also note that many Target Symbols occur more than once in the FDA
-              PMTL Landing Page by design. Any target derived from multiple FDA
+              Also note that many Target Symbols occur more than once in
+              the {fdaPmtlPage.label} by design. Any target derived from multiple FDA
               Targets will appear once for each FDA Target. For example, BRAF is
               derived from three separate FDA Targets: “BRAF | Gene Abnormality:
               BRAF”, “ERK | Gene Abnormality: BRAF, MAP2K1”, and “MEK | Gene
               Abnormality: BRAF and BRAF gene fusions, MAP2K1, NF1”. Searching
-              the Target Symbol column for “BRAF” on the FDA PMTL Landing Page
-              will show all of these derivations separately.
+              the Target Symbol column for “BRAF” on the {fdaPmtlPage.label} will show
+              all of these derivations separately.
             </Typography>
           </Grid>
 
@@ -426,8 +427,8 @@ function PMTLDocPage() {
             <Typography paragraph>
               The table below contains examples and descriptions of each column
               within the searchable{' '}
-              <Link to={fdaPMTL}>
-                <b> FDA PMTL Landing Page</b>
+              <Link to={fdaPmtlPage.url}>
+                <b> {fdaPmtlPage.label}</b>
               </Link>
               .
             </Typography>

--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -24,6 +24,8 @@ import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 import { mtpPageNames } from '../../constants';
 import PMTLData from './PMTL.json';
 
+const { mtpPmtlDocPage } = mtpPageNames;
+
 function getRows(downloadData) {
   const rows = [];
   downloadData.forEach(mapping => {
@@ -173,7 +175,7 @@ function getColumns(
       tooltip: {
         badgeContent: () => (
           <Lk
-            href="/fda-pmtl-docs#mapping-description"
+            href={`${mtpPmtlDocPage.url}#mapping-description`}
             title="Explanation of 'Mapping Description' column"
           >
             <FontAwesomeIcon icon={faInfoCircle} size="sm" />
@@ -356,7 +358,6 @@ class PMTLPage extends Component {
       this.mappingDescriptionFilterHandler
     );
     const rowsPerPageOptions = [10, 25, 50];
-    const { mtpPmtlDocPage } = mtpPageNames;
     const FDA_Publication =
       'https://www.fda.gov/about-fda/oncology-center-excellence/pediatric-oncology#target';
 
@@ -404,7 +405,7 @@ class PMTLPage extends Component {
             {loading || error ? null : (
               <>
                 <Lk
-                  href="/fda-pmtl-docs#colums-description"
+                  href={`${mtpPmtlDocPage.url}#colums-description`}
                   title="FDA PMTL Columns Description"
                 >
                   <FontAwesomeIcon icon={faInfoCircle} size="md" /> Columns

--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -21,6 +21,7 @@ import NonRelevantIcon from '../../components/RMTL/NonRelevantIcon';
 import UnspecifiedIcon from '../../components/RMTL/UnspecifiedIcon';
 import ScrollToTop from '../../components/ScrollToTop';
 import ExternalLinkIcon from '../../components/ExternalLinkIcon';
+import { mtpPageNames } from '../../constants';
 import PMTLData from './PMTL.json';
 
 function getRows(downloadData) {
@@ -355,7 +356,7 @@ class PMTLPage extends Component {
       this.mappingDescriptionFilterHandler
     );
     const rowsPerPageOptions = [10, 25, 50];
-    const FDA_PMTL_DocumentationUrl = '/fda-pmtl-docs';
+    const { mtpPmtlDocPage } = mtpPageNames;
     const FDA_Publication =
       'https://www.fda.gov/about-fda/oncology-center-excellence/pediatric-oncology#target';
 
@@ -368,7 +369,7 @@ class PMTLPage extends Component {
         </Typography>
         <br />
         <Typography paragraph>
-          <Link to={FDA_PMTL_DocumentationUrl}> Version 1.1 </Link>
+          <Link to={mtpPmtlDocPage.url}> Version 1.1 </Link>
         </Typography>
         <hr />
         <br />
@@ -378,10 +379,9 @@ class PMTLPage extends Component {
           requirements associated with drug development. The table below is a
           computable interpretation of the target lists published by the FDA.
           See our{' '}
-          <Link to={FDA_PMTL_DocumentationUrl}>
-            {' '}
-            <b>FDA PMTL Documentation </b>
-          </Link>
+          <Link to={mtpPmtlDocPage.url}>
+            <b>{mtpPmtlDocPage.label}</b>
+          </Link>{' '}
           or the official{' '}
           <Link external to={FDA_Publication}>
             <b>FDA publication</b>


### PR DESCRIPTION
In this PR, two page has been renamed:
- Rename `FDA PMTL Landing Page` to `FDA Pediatric Molecular Target Lists`
- Rename `FDA PMTL Documentation` to `MTP PMTL Documentation`
- Rename internal URL from `/fda-pmtl-docs` to `/mtp-pmtl-docs`

Related Ticket: CCDIMTP-49, CCDIMTP-47