### PR TITLE
CCDIMTP-170 & CCDIMTP-176

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -13,7 +13,7 @@ const styles = theme => ({
     margin: 0,
     width: '100%',
     zIndex: theme.zIndex.navbar,
-    top: 183, // NCINavBar take 59 px
+    top: theme.header.height,
   },
   navbarHomepage: {
     left: 0,

--- a/src/pages/ChangeLogPage/ChangeLogView.js
+++ b/src/pages/ChangeLogPage/ChangeLogView.js
@@ -16,6 +16,8 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: '#EDF1F4',
     color: '#000000',
     fontSize: '16px',
+  },
+  introContainer: {
     marginTop: theme.header.height,
     padding: `${theme.header.spacing} 40px 68px`,
     '@media (max-width: 360px)': {

--- a/src/theme.js
+++ b/src/theme.js
@@ -139,8 +139,8 @@ const theme = {
   },
   Drawer: {
     paper: {
-      marginTop: '232px',
-      height: 'calc(100% - 232px)',
+      marginTop: '230px', // NCILinkBar(23px), NCILogoBar(100px), NCINavBar(59px), and NavBar(48px)
+      height: 'calc(100% - 230px)',
     },
   },
   zIndex: {
@@ -148,7 +148,7 @@ const theme = {
     navPanel: 1001,
   },
   header: {
-    height: '159px', // 100px for NCILogoBar and 59px for NCINavBar
+    height: '182px', // // NCILinkBar(23px), NCILogoBar(100px), and NCINavBar(59px)
     spacing: '52px', // spacing below the header
   },
 };


### PR DESCRIPTION
In this PR:
- `NCILinkBar` component is now visible at the top of `Change Log` page
- Spacing issue caused by adjusting the implementation of NCILinkBar in https://github.com/CBIIT/mtp-frontend/pull/233 PR is fixed.
- The space between Header and page content is standardized:
  - `52px` spacing for MTP created pages.(`PCDN`, `About`,` FDA PMTL`, `Doc`, etc page ...)
  - `36px` spacing for OT inherited pages (ex. `Target`, `Evidence`, `Disease`, `Drug`, etc pages ...)

Related Ticket: CCDIMTP-170, CCDIMTP-176