### PR TITLE
CCDIMTP-179

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,11 +10,9 @@ import { globalQuery } from './GlobalQuery';
 import HomePage from './pages/HomePage';
 import SearchPage from './pages/SearchPage';
 import DiseasePage from './pages/DiseasePage';
-import DownloadsPage from './pages/DownloadsPage';
 import DrugPage from './pages/DrugPage';
 import TargetPage from './pages/TargetPage';
 import EvidencePage from './pages/EvidencePage';
-import VariantsPage from './pages/VariantsPage';
 import APIPage from './pages/APIPage';
 import PMTLDocPage from './pages/PMTLDocPage';
 import NotFoundPage from './pages/NotFoundPage';
@@ -37,7 +35,6 @@ class App extends Component {
               <Switch>
                 <Route exact path="/" component={HomePage} />
                 <Route path="/search" component={SearchPage} />
-                <Route path="/downloads" component={DownloadsPage} />
                 <Route path="/disease/:efoId" component={DiseasePage} />
                 <Route path="/target/:ensgId" component={TargetPage} />
                 <Route path="/drug/:chemblId" component={DrugPage} />
@@ -45,7 +42,6 @@ class App extends Component {
                   path="/evidence/:ensgId/:efoId"
                   component={EvidencePage}
                 />
-                <Route path="/variants" component={VariantsPage} />
                 <Route path="/api" component={APIPage} />
                 <Route path="/About" component={AboutPage} />
                 <Route path="/fda-pmtl" component={PMTLPage} />

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -894,7 +894,15 @@ const AboutView = ({ data }) => {
               <Typography paragraph className={classes.space}>
                 The Open Targets Platform undergoes regular updates to add new
                 data and functionalities, which are integrated into the
-                Molecular Targets Platform as soon as possible.
+                Molecular Targets Platform as soon as possible. To access
+                Open Targets Platform data releases directly, please see their{' '}
+                <Link
+                  to="https://platform.opentargets.org/downloads"
+                  external
+                >
+                  Data Downloads
+                  <ExternalLinkIcon />
+                </Link>.
               </Typography>
 
               <hr className={classes.containerDiverHr} />


### PR DESCRIPTION
In this PR:
- Route to Data Downloads page is removed from MTP
- Route Variants page is removed from MTP
- About Page is updated to link out to OTP Data Downloads page.

Related Ticket: CCDIMTP-179