### PR TITLE
CCDIMTP-366

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -331,3 +331,7 @@ export const mtpPageNames = {
     url: '/mtp-pmtl-docs',
   },
 };
+
+export const mtpLinks = {
+  openPedCan: 'https://github.com/PediatricOpenTargets/documentation',
+}

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -13,6 +13,7 @@ import NonRelevantIcon from '../../components/RMTL/NonRelevantIcon';
 import UnspecifiedIcon from '../../components/RMTL/UnspecifiedIcon';
 import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 import Infographic from '../../assets/about/Infographic.png';
+import { mtpLinks } from '../../constants';
 
 const useStyles = makeStyles(theme => ({
   paper: {
@@ -266,11 +267,11 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE:
           <Link
-            to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis"
+            to={mtpLinks.openPedCan}
             external
           >
             {' '}
-            OpenPedCan (v10)
+            OpenPedCan
             <ExternalLinkIcon />{' '}
           </Link>
           <br />
@@ -520,14 +521,11 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE:
           <Link
-            to={
-              'https://github.com/PediatricOpenTargets/OpenPedCan-analysis/blob/' +
-              '4fb04fe60754b90da3c241dbb8b727c3722487cc/doc/release-notes.md'
-            }
+            to={mtpLinks.openPedCan}
             external
           >
             {' '}
-            OpenPedCan (v10)
+            OpenPedCan
             <ExternalLinkIcon />
           </Link>
         </p>
@@ -581,11 +579,11 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE:
           <Link
-            to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis"
+            to={mtpLinks.openPedCan}
             external
           >
             {' '}
-            OpenPedCan (v10)
+            OpenPedCan
             <ExternalLinkIcon />
           </Link>
           {', '}
@@ -662,11 +660,11 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE:
           <Link
-            to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis"
+            to={mtpLinks.openPedCan}
             external
           >
             {' '}
-            OpenPedCan (v10)
+            OpenPedCan
             <ExternalLinkIcon />
           </Link>
           ,
@@ -1085,7 +1083,7 @@ const AboutView = ({ data }) => {
                 and drug development. To read more about the OpenPedCan data
                 processing methods, view the{' '}
                 <Link
-                  to="https://github.com/PediatricOpenTargets/documentation"
+                  to={mtpLinks.openPedCan}
                   external
                 >
                   documentation

--- a/src/pages/ChangeLogPage/ChangeLogView.js
+++ b/src/pages/ChangeLogPage/ChangeLogView.js
@@ -5,7 +5,7 @@ import NCIFooter from '../../components/NCIFooter';
 import NCIHeader from '../../components/NCIHeader';
 import ScrollToTop from '../../components/ScrollToTop';
 import Link from '../../components/Link';
-import { appDescription, appCanonicalUrl, version, mtpPageNames } from '../../constants';
+import { appDescription, appCanonicalUrl, version, mtpPageNames, mtpLinks } from '../../constants';
 import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 import usePlatformApi from '../../hooks/usePlatformApi';
 import useConfigVersion from '../../hooks/useConfigVersion';
@@ -201,7 +201,7 @@ const ChangeLogView = ({ data }) => {
                   <b>Version in use</b>: {getVersion(openPedCanAnalyses, 'v')} <br />
                   <b>Detailed Change Log</b>:
                   <Link
-                    to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis/blob/4fb04fe60754b90da3c241dbb8b727c3722487cc/doc/release-notes.md"
+                    to={mtpLinks.openPedCan}
                     external
                   >
                     {' '}

--- a/src/sections/evidence/OpenPedCanGeneExpression/Description.js
+++ b/src/sections/evidence/OpenPedCanGeneExpression/Description.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from '../../../components/Link';
+import { mtpLinks } from '../../../constants';
 
 const Description = ({ symbol, name }) => (
   <>
@@ -7,10 +8,10 @@ const Description = ({ symbol, name }) => (
     <strong> {symbol} </strong> in pediatric
     <strong> {name} </strong> with human adult normal tissues from GTEx. Source:{' '}
     <Link
-      to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis"
+      to={mtpLinks.openPedCan}
       external
     >
-      OpenPedCan (v10)
+      OpenPedCan
     </Link>
     {', '}
     <Link to="https://www.gtexportal.org/home/" external>

--- a/src/sections/evidence/OpenPedCanSomaticAlterations/Description.js
+++ b/src/sections/evidence/OpenPedCanSomaticAlterations/Description.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import Link from '../../../components/Link';
+import { mtpLinks } from '../../../constants';
 
 const Description = ({ symbol, name }) => (
   <>
     Somatic alterations associated with <strong>{symbol}</strong> in pediatric{' '}
     <strong>{name}</strong>. Source:{' '}
     <Link
-      to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis"
+      to={mtpLinks.openPedCan}
       external
     >
-      OpenPedCan (v10)
+      OpenPedCan
     </Link>
     {', '}
     <Link

--- a/src/sections/target/OpenPedCanGeneExpression/Description.js
+++ b/src/sections/target/OpenPedCanGeneExpression/Description.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import Link from '../../../components/Link';
+import { mtpLinks } from '../../../constants';
 
 const Description = ({ symbol }) => (
   <>
     mRNA expression of
     <strong> {symbol} </strong> in pediatric tumors. Source:{' '}
     <Link
-      to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis"
+      to={mtpLinks.openPedCan}
       external
     >
-      OpenPedCan (v10)
+      OpenPedCan
     </Link>
     {', '}
     <Link

--- a/src/sections/target/OpenPedCanSomaticAlterations/Description.js
+++ b/src/sections/target/OpenPedCanSomaticAlterations/Description.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import Link from '../../../components/Link';
+import { mtpLinks } from '../../../constants';
 
 const Description = ({ symbol }) => (
   <>
     Somatic alterations associated with <strong>{symbol}</strong> in pediatric
     cancers. Source:{' '}
     <Link
-      to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis"
+      to={mtpLinks.openPedCan}
       external
     >
-      OpenPedCan (v10)
+      OpenPedCan
     </Link>
     {', '}
     <Link


### PR DESCRIPTION
In this PR, All existing MTP links to CHoP's OpenPedCan-analysis repo are replaced with links to CHoP's documentation repo.
Following two url are replaced by (https://github.com/PediatricOpenTargets/documentation)
- https://github.com/PediatricOpenTargets/OpenPedCan-analysis
- https://github.com/PediatricOpenTargets/OpenPedCan-analysis/blob/4fb04fe60754b90da3c241dbb8b727c3722487cc/doc/release-notes.md