### PR TITLE
CCDIMTP-413

### DIFF
--- a/src/components/NCINavBar/index.js
+++ b/src/components/NCINavBar/index.js
@@ -84,7 +84,7 @@ export const navBarData = [
       },
       {
         labelText: 'Latest Release',
-        link: 'Latest-Release.pdf',
+        link: '/Latest-Release.pdf',
         pageType: 'file',
       },
       {


### PR DESCRIPTION
In this PR, a missing `/` is added to correctly navigate to the Latest Release pdf from any page in the application.

Bug Ticket: CCDIMTP-413